### PR TITLE
Fix merge conflict markers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-<<<<<<< HEAD
 # fbet_ui
-=======
+
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Getting Started
@@ -37,4 +36,3 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
->>>>>>> 2672f5e (Initial commit from Create Next App)


### PR DESCRIPTION
## Summary
- clean up `README.md` that still contained merge conflict markers

## Testing
- `npm test` *(fails: Playwright tests executed by Vitest)*

------
https://chatgpt.com/codex/tasks/task_e_684042c3ed548324af2f696a830d5571