### PR TITLE
Fix push notification URL

### DIFF
--- a/src/app/api/services/notificationService.ts
+++ b/src/app/api/services/notificationService.ts
@@ -62,7 +62,7 @@ export async function sendNewEventNotificationsToGroupMembers(
       icon: '/icon1.png', // Stelle sicher, dass dieses Icon in /public existiert
       data: {
         // Daten, die der Service Worker beim Klick verwenden kann
-        url: `/dashboard?group=<span class="math-inline">\{event\.groupId\}&event\=</span>{event.id}`,
+        url: `/dashboard?group=${event.groupId}&event=${event.id}`,
       },
     });
 


### PR DESCRIPTION
## Summary
- fix dynamic URL in `notificationService` for push notifications

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405d1d2b44832499929ee95cd8c7b7