### PR TITLE
Add push notification test route

### DIFF
--- a/src/app/api/push/test/route.ts
+++ b/src/app/api/push/test/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUserFromRequest } from '@/app/api/lib/auth';
+import { sendTestNotificationToUser } from '@/app/api/services/notificationService';
+
+export async function POST(req: NextRequest) {
+  const currentUser = await getCurrentUserFromRequest(req);
+  if (!currentUser) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    await sendTestNotificationToUser(currentUser.id);
+    return NextResponse.json({ message: 'Test notification sent' });
+  } catch (error) {
+    console.error('[API /push/test] Error sending test notification:', error);
+    return NextResponse.json(
+      { error: 'Failed to send test notification' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/components/layout/AppHeader.tsx
+++ b/src/app/components/layout/AppHeader.tsx
@@ -101,6 +101,7 @@ export function AppHeader({
     error: pushError, // Dies ist die Fehlermeldung vom Hook
     requestPermissionAndSubscribe,
     unsubscribeUser,
+    triggerTestNotification,
     isSubscribed: isPushSubscribed,
     isLoading: isPushLoading,
     permissionDenied: isPushPermissionDenied,
@@ -218,6 +219,7 @@ export function AppHeader({
       const success = await requestPermissionAndSubscribe();
       if (success) {
         toast.success('Push-Benachrichtigungen aktiviert!');
+        triggerTestNotification();
       } else {
         // Spezifische Behandlung, falls die Berechtigung verweigert wurde und der Hook dies nicht schon als 'pushError' gemeldet hat
         // (Der Hook sollte das aber bereits im 'pushError' State abbilden)

--- a/src/app/hooks/usePushNotifications.ts
+++ b/src/app/hooks/usePushNotifications.ts
@@ -154,6 +154,11 @@ export function usePushNotifications() {
         setCurrentSubscription(subscription);
         setStatus(PushNotificationStatus.SUPPORTED_SUBSCRIBED);
         setError(null);
+        try {
+          await fetch('/api/push/test', { method: 'POST' });
+        } catch (e) {
+          console.error('[usePushNotifications] Failed to send test notification:', e);
+        }
         return true;
       } catch (err: any) {
         // ... (Fehlerbehandlung bleibt ähnlich) ...
@@ -244,6 +249,16 @@ export function usePushNotifications() {
     }
   }, [isPushApiSupported, currentSubscription, checkSubscriptionStatus]);
 
+  const triggerTestNotification = useCallback(async (): Promise<boolean> => {
+    try {
+      const res = await fetch('/api/push/test', { method: 'POST' });
+      return res.ok;
+    } catch (e) {
+      console.error('[usePushNotifications] Failed to trigger test push:', e);
+      return false;
+    }
+  }, []);
+
   return {
     // ... (Return-Objekt bleibt gleich) ...
     status,
@@ -251,6 +266,7 @@ export function usePushNotifications() {
     requestPermissionAndSubscribe,
     unsubscribeUser,
     checkSubscriptionStatus,
+    triggerTestNotification,
     isSubscribed: status === PushNotificationStatus.SUPPORTED_SUBSCRIBED,
     canSubscribe: status === PushNotificationStatus.SUPPORTED_NOT_SUBSCRIBED,
     permissionDenied: status === PushNotificationStatus.PERMISSION_DENIED,


### PR DESCRIPTION
## Summary
- allow sending a push test message from server
- auto send a test message after subscribing
- expose `triggerTestNotification` hook

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408b47dac08324bb45a5929c5572dd