### PR TITLE
Add GroupDetailsSection tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tw-animate-css": "^1.2.8",
         "typescript": "^5",
+        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.1.2"
       }
     },
@@ -10090,6 +10091,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gm": {
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/gm/-/gm-1.25.1.tgz",
@@ -16047,6 +16055,27 @@
       "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
       "license": "Apache-2.0"
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -16691,6 +16720,26 @@
         "next": "^14.1.0 || ^15.0.0",
         "storybook": "^8.3.0",
         "vite": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite/node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.2.8",
     "typescript": "^5",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.1.2"
   },
   "eslintConfig": {

--- a/src/app/components/dashboard/GroupDetailsSection.test.tsx
+++ b/src/app/components/dashboard/GroupDetailsSection.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+import { GroupDetailsSection } from './GroupDetailsSection';
+
+// Mock child components to avoid complex implementations
+vi.mock('./SelectedGroupView', () => ({
+  SelectedGroupView: () => <div data-testid="selected-group-view" />,
+}));
+
+vi.mock('@/app/components/ui/card', () => ({
+  Card: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card">{children}</div>
+  ),
+  CardHeader: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card-header">{children}</div>
+  ),
+  CardContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card-content">{children}</div>
+  ),
+}));
+
+vi.mock('@/app/components/ui/skeleton', () => ({
+  Skeleton: () => <div data-testid="skeleton" />,
+}));
+
+// Icons can be simple stubs
+vi.mock('lucide-react', () => ({
+  Users: () => <svg data-testid="users-icon" />,
+  TriangleAlert: () => <svg data-testid="triangle-icon" />,
+}));
+
+// Helper data
+const baseProps = {
+  selectedGroupId: null as number | null,
+  selectedGroupDetails: null,
+  selectedGroupEvents: [],
+  userSubmittedTips: {},
+  allTipsPerEvent: {},
+  highscoreEntries: null,
+  user: { id: 1, name: 'Test' } as any,
+  isGroupDataLoading: false,
+  groupDataError: null,
+  interactions: {} as any,
+  onDeleteGroupInPage: vi.fn(),
+  onImageChanged: vi.fn(),
+};
+
+describe('GroupDetailsSection', () => {
+  it('shows placeholder when no group is selected', () => {
+    render(<GroupDetailsSection {...baseProps} />);
+
+    expect(
+      screen.getByText(/Bitte wähle links eine Gruppe aus/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders skeleton while loading', () => {
+    render(
+      <GroupDetailsSection
+        {...baseProps}
+        isGroupDataLoading={true}
+      />
+    );
+
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('renders skeleton when id is set but details missing', () => {
+    render(
+      <GroupDetailsSection
+        {...baseProps}
+        selectedGroupId={5}
+        selectedGroupDetails={null}
+      />
+    );
+
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('displays error message when groupDataError present', () => {
+    render(
+      <GroupDetailsSection
+        {...baseProps}
+        selectedGroupId={2}
+        selectedGroupDetails={null}
+        groupDataError="Something went wrong"
+      />
+    );
+
+    expect(
+      screen.getByText(/Fehler beim Laden der Gruppe/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+  });
+
+  it('renders SelectedGroupView with valid group', () => {
+    render(
+      <GroupDetailsSection
+        {...baseProps}
+        selectedGroupId={1}
+        selectedGroupDetails={{ id: 1 } as any}
+      />
+    );
+
+    expect(screen.getByTestId('selected-group-view')).toBeInTheDocument();
+  });
+});
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  esbuild: {
+    jsx: 'automatic',
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add Vitest config and setup for jsdom testing
- mock dashboard children in GroupDetailsSection tests
- test placeholder, loading, error, and valid states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68444cc9a624832497e4c1f1ab99a961