### PR TITLE
Fix login tests and adjust API routes

### DIFF
--- a/tests/add-event-dialog.spec.ts
+++ b/tests/add-event-dialog.spec.ts
@@ -37,10 +37,10 @@ async function openGroup(page: Page) {
  * ------------------------------------------------------------------ */
 function mockDashboardRoutes(page: Page) {
   /* ---------- Auth ---------- */
-  page.route('**/users/login', (r) =>
+  page.route('**/api/auth/login', (r) =>
     r.fulfill({ status: 200, body: JSON.stringify(fakeToken) })
   );
-  page.route('**/users/me', (r) =>
+  page.route('**/api/auth/me', (r) =>
     r.fulfill({ status: 200, body: JSON.stringify(fakeUser) })
   );
 

--- a/tests/group.spec.ts
+++ b/tests/group.spec.ts
@@ -15,7 +15,7 @@ test.describe('CreateGroup-Seite (nach Login)', () => {
   /* ---------- Gemeinsame Mocks & Login ---------- */
   test.beforeEach(async ({ page }) => {
     /* 1) Login-Endpunkt */
-    await page.route('**/users/login', async (route: Route, req: Request) => {
+    await page.route('**/api/auth/login', async (route: Route, req: Request) => {
       if (req.method() === 'POST') {
         await route.fulfill({
           status: 200,
@@ -27,8 +27,8 @@ test.describe('CreateGroup-Seite (nach Login)', () => {
       }
     });
 
-    /* 2) /users/me – liefert sofort den User */
-    await page.route('**/users/me', async (route) =>
+    /* 2) /auth/me – liefert sofort den User */
+    await page.route('**/api/auth/me', async (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/tests/helpers/login.ts
+++ b/tests/helpers/login.ts
@@ -16,11 +16,13 @@ export async function loginUI(page: Page) {
   await page.goto('/login');
 
   // 2) Felder über <label> finden und füllen
-  await page.getByLabel(/^e-mail$/i).fill(email);
-  await page.getByLabel(/^passwort$/i).fill(pw);
+  // Beim Rendern kann das Label Sonderzeichen enthalten. Über die Platzhalter
+  // treffen wir die Felder zuverlässiger.
+  await page.getByPlaceholder('name@example.com').fill(email);
+  await page.getByPlaceholder('••••••••').fill(pw);
 
   // 3) Absenden
-  await page.getByRole('button', { name: /^login$/i }).click();
+  await page.getByRole('button', { name: /anmelden/i }).click();
 
   // 4) Auf Redirect ODER Dashboard-Root warten (max. 20 s)
   await Promise.race([


### PR DESCRIPTION
## Summary
- adjust global-setup to allow skipping when creds are missing
- update login helper to use placeholders and new button text
- adapt login.spec to new UI labels and token shortcut
- update group and add-event-dialog tests to new auth API

## Testing
- `npx playwright test tests/login.spec.ts --project=chromium`
- `npx playwright test --project=chromium` *(fails: 9 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6844496513d88324b5b9cc5bcab5122b