### PR TITLE
Fix group header description overflow

### DIFF
--- a/src/app/components/dashboard/GroupHeaderCard.tsx
+++ b/src/app/components/dashboard/GroupHeaderCard.tsx
@@ -147,9 +147,11 @@ export function GroupHeaderCard({
                   </div>
                 )}
                 {group.description && (
-                  <div className='flex items-center gap-x-1'>
+                  <div className='flex items-center gap-x-1 max-w-full'>
                     <Info className='h-4 w-4' />
-                    <span className='truncate'>{group.description}</span>
+                    <span className='break-words whitespace-normal'>
+                      {group.description}
+                    </span>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- prevent long group description from overflowing the header card

## Testing
- `npm run lint` *(fails: prettier/next warnings)*
- `npm test` *(fails: Playwright tests error about `test.describe` usage)*

------
https://chatgpt.com/codex/tasks/task_e_6844641794c88324bb224cc8840e7835