### PR TITLE
Add unit tests for utility modules

### DIFF
--- a/src/app/api/lib/hash.test.ts
+++ b/src/app/api/lib/hash.test.ts
@@ -1,0 +1,15 @@
+import { hashPassword, verifyPassword } from './hash';
+import { describe, it, expect } from 'vitest';
+
+describe('hash helpers', () => {
+  it('hashes and verifies password', async () => {
+    const hash = await hashPassword('secret');
+    expect(hash).not.toBe('secret');
+    expect(await verifyPassword('secret', hash)).toBe(true);
+  });
+
+  it('fails verification on wrong password', async () => {
+    const hash = await hashPassword('secret');
+    expect(await verifyPassword('wrong', hash)).toBe(false);
+  });
+});

--- a/src/app/api/lib/jwt.test.ts
+++ b/src/app/api/lib/jwt.test.ts
@@ -1,0 +1,24 @@
+import { signJwt, verifyJwt } from './jwt';
+import { vi, describe, it, expect, beforeEach, afterAll } from 'vitest';
+
+describe('jwt helpers', () => {
+  const OLD_ENV = process.env;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV, SECRET_KEY: 'testsecret', ACCESS_TOKEN_EXPIRE_DAYS: '1d' };
+  });
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('signs and verifies a token', () => {
+    const token = signJwt({ sub: 1 });
+    const decoded = verifyJwt(token);
+    expect(decoded?.sub).toBe('1');
+  });
+
+  it('returns null for invalid token', () => {
+    const bad = verifyJwt('bad.token');
+    expect(bad).toBeNull();
+  });
+});

--- a/src/app/api/services/football_schedule.test.ts
+++ b/src/app/api/services/football_schedule.test.ts
@@ -1,0 +1,16 @@
+import { addDays, calculateWeeksBetween } from './football_schedule';
+import { describe, it, expect } from 'vitest';
+
+describe('football schedule utilities', () => {
+  it('adds days to date', () => {
+    const d = new Date('2020-01-01T00:00:00Z');
+    const result = addDays(d, 5);
+    expect(result.toISOString()).toBe('2020-01-06T00:00:00.000Z');
+  });
+
+  it('calculates weeks between dates', () => {
+    const from = new Date('2020-01-01T00:00:00Z');
+    const to = new Date('2020-01-20T00:00:00Z');
+    expect(calculateWeeksBetween(from, to)).toBe(4);
+  });
+});

--- a/src/app/api/services/highscoreService.test.ts
+++ b/src/app/api/services/highscoreService.test.ts
@@ -1,0 +1,48 @@
+import { getHighscoreForGroup } from './highscoreService';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+type Member = { id: number; name: string | null; email: string | null };
+
+type Score = { userId: number; _sum: { points: number | null } };
+
+vi.mock('@/app/api/lib/prisma', () => {
+  return {
+    prisma: {
+      user: { findMany: vi.fn() },
+      tip: { groupBy: vi.fn() },
+    },
+  };
+});
+
+const { prisma } = await import('@/app/api/lib/prisma');
+
+describe('getHighscoreForGroup', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns empty array when no members', async () => {
+    (prisma.user.findMany as any).mockResolvedValue([]);
+    const result = await getHighscoreForGroup(1);
+    expect(result).toEqual([]);
+  });
+
+  it('aggregates and sorts scores', async () => {
+    const members: Member[] = [
+      { id: 1, name: 'Alice', email: 'a@x.com' },
+      { id: 2, name: null, email: 'bob@x.com' },
+    ];
+    const scores: Score[] = [
+      { userId: 1, _sum: { points: 5 } },
+      { userId: 2, _sum: { points: 10 } },
+    ];
+    (prisma.user.findMany as any).mockResolvedValue(members);
+    (prisma.tip.groupBy as any).mockResolvedValue(scores);
+
+    const result = await getHighscoreForGroup(123);
+    expect(result).toEqual([
+      { user_id: 2, name: 'bob', points: 10 },
+      { user_id: 1, name: 'Alice', points: 5 },
+    ]);
+  });
+});

--- a/src/app/lib/utils.test.tsx
+++ b/src/app/lib/utils.test.tsx
@@ -1,0 +1,25 @@
+import { getSportIcon, getCategoryIcon, cn } from './utils';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+describe('utils', () => {
+  beforeAll(() => {
+    // ensure React is available for classic runtime JSX
+    // @ts-ignore
+    globalThis.React = React;
+  });
+  it('returns sport icon react elements', () => {
+    const { container } = render(<>{getSportIcon('ufc')}</>);
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('returns category icon react elements', () => {
+    const { container } = render(<>{getCategoryIcon('boxen')}</>);
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('merges class names', () => {
+    expect(cn('a', false && 'b', 'c')).toBe('a c');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    exclude: ['tests/**'],
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest configuration with path alias
- test JWT sign/verify logic
- test password hash helpers
- test highscore computation with mocked Prisma
- test football_schedule helper functions
- test basic React utility helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844891bde44832482b21b3f849a71cc