### PR TITLE
Add unit tests for service utilities

### DIFF
--- a/src/app/api/lib/auth.test.ts
+++ b/src/app/api/lib/auth.test.ts
@@ -1,0 +1,58 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+vi.mock('./jwt', () => ({ verifyJwt: vi.fn() }));
+vi.mock('./prisma', () => ({ prisma: { user: { findUnique: vi.fn() } } }));
+
+const { verifyJwt } = await import('./jwt');
+const { prisma } = await import('./prisma');
+const { getCurrentUserFromRequest } = await import('./auth');
+
+describe('getCurrentUserFromRequest', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns user from Authorization header', async () => {
+    const req: any = {
+      headers: new Headers({ Authorization: 'Bearer token' }),
+      cookies: { get: () => undefined },
+    };
+    (verifyJwt as any).mockReturnValue({ sub: '1' });
+    (prisma.user.findUnique as any).mockResolvedValue({
+      id: 1,
+      email: 'a@example.com',
+      name: 'Alice',
+      isActive: true,
+    });
+    const result = await getCurrentUserFromRequest(req);
+    expect(verifyJwt).toHaveBeenCalledWith('token');
+    expect(result?.id).toBe(1);
+  });
+
+  it('falls back to cookie token', async () => {
+    const req: any = {
+      headers: new Headers({ Authorization: 'Bearer null' }),
+      cookies: { get: () => ({ value: 'cookie-token' }) },
+    };
+    (verifyJwt as any).mockReturnValue({ sub: '2' });
+    (prisma.user.findUnique as any).mockResolvedValue({
+      id: 2,
+      email: 'b@example.com',
+      name: 'Bob',
+      isActive: true,
+    });
+    const result = await getCurrentUserFromRequest(req);
+    expect(verifyJwt).toHaveBeenCalledWith('cookie-token');
+    expect(result?.id).toBe(2);
+  });
+
+  it('returns null for invalid token', async () => {
+    const req: any = {
+      headers: new Headers({ Authorization: 'Bearer bad' }),
+      cookies: { get: () => undefined },
+    };
+    (verifyJwt as any).mockReturnValue(null);
+    const result = await getCurrentUserFromRequest(req);
+    expect(result).toBeNull();
+  });
+});

--- a/src/app/api/services/eventService.test.ts
+++ b/src/app/api/services/eventService.test.ts
@@ -1,0 +1,121 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+vi.mock('@/app/api/lib/prisma', () => ({
+  prisma: {
+    event: { findMany: vi.fn(), update: vi.fn() },
+  },
+}));
+
+const { prisma } = await import('@/app/api/lib/prisma');
+const { getEventsForGroup, setEventResult } = await import('./eventService');
+const { Prisma } = await import('@prisma/client');
+
+describe('eventService', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('getEventsForGroup', () => {
+    it('maps prisma events to client events', async () => {
+      const now = new Date();
+      const events = [
+        {
+          id: 1,
+          title: 'E1',
+          groupId: 9,
+          options: ['a', 'b'],
+          hasWildcard: true,
+          wildcardType: 'EXACT_SCORE',
+          wildcardPrompt: 'prompt',
+          wildcardAnswer: null,
+          createdAt: now,
+          tips: [
+            {
+              userId: 1,
+              selectedOption: 'a',
+              wildcardGuess: '1:0',
+              points: 1,
+              wildcardPoints: 2,
+              user: { id: 1, name: 'Alice', email: 'alice@example.com' },
+            },
+            {
+              userId: 2,
+              selectedOption: 'b',
+              wildcardGuess: null,
+              points: null,
+              wildcardPoints: null,
+              user: { id: 2, name: null, email: 'bob@example.com' },
+            },
+          ],
+          creator: { id: 10, name: 'Creator' },
+        },
+        {
+          id: 2,
+          title: 'E2',
+          groupId: 9,
+          options: ['a', 1],
+          hasWildcard: false,
+          wildcardType: null,
+          wildcardPrompt: null,
+          wildcardAnswer: null,
+          createdAt: now,
+          tips: [],
+          creator: { id: 10, name: 'Creator' },
+        },
+      ];
+      (prisma.event.findMany as any).mockResolvedValue(events);
+
+      const result = await getEventsForGroup(9);
+      expect(prisma.event.findMany).toHaveBeenCalled();
+      expect(result[0].awardedPoints).toEqual([
+        {
+          userId: 1,
+          userName: 'Alice',
+          selectedOption: 'a',
+          wildcardGuess: '1:0',
+          points: 1,
+          wildcardPoints: 2,
+        },
+        {
+          userId: 2,
+          userName: 'bob',
+          selectedOption: 'b',
+          wildcardGuess: null,
+          points: null,
+          wildcardPoints: null,
+        },
+      ]);
+      expect(result[0].options).toEqual(['a', 'b']);
+      expect(result[1].options).toEqual([]); // invalid options filtered
+    });
+  });
+
+  describe('setEventResult', () => {
+    it('returns updated event', async () => {
+      const updated = { id: 1, winningOption: 'A', wildcardAnswer: 'x' };
+      (prisma.event.update as any).mockResolvedValue(updated);
+      const result = await setEventResult(1, 'A', 'x');
+      expect(prisma.event.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { winningOption: 'A', wildcardAnswer: 'x' },
+      });
+      expect(result).toBe(updated);
+    });
+
+    it('returns null when event not found', async () => {
+      const error = new Prisma.PrismaClientKnownRequestError('err', {
+        code: 'P2025',
+        clientVersion: '1',
+      });
+      (prisma.event.update as any).mockRejectedValue(error);
+      const result = await setEventResult(1, 'A');
+      expect(result).toBeNull();
+    });
+
+    it('throws other errors', async () => {
+      const err = new Error('fail');
+      (prisma.event.update as any).mockRejectedValue(err);
+      await expect(setEventResult(1, 'A')).rejects.toThrow('fail');
+    });
+  });
+});

--- a/src/app/api/services/groupService.test.ts
+++ b/src/app/api/services/groupService.test.ts
@@ -1,0 +1,90 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+vi.mock('uuid', () => ({ v4: vi.fn(() => 'test-uuid') }));
+vi.mock('@/app/api/lib/prisma', () => ({
+  prisma: {
+    groupMembership: { findFirst: vi.fn(), create: vi.fn() },
+    group: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}));
+
+const { prisma } = await import('@/app/api/lib/prisma');
+const { v4: uuidv4 } = await import('uuid');
+const {
+  isUserMemberOfGroup,
+  addUserToGroup,
+  regenerateInviteTokenForGroup,
+} = await import('./groupService');
+
+describe('groupService', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('isUserMemberOfGroup', () => {
+    it('returns true when membership exists', async () => {
+      (prisma.groupMembership.findFirst as any).mockResolvedValue({ id: 1 });
+      const result = await isUserMemberOfGroup(1, 2);
+      expect(result).toBe(true);
+      expect(prisma.groupMembership.findFirst).toHaveBeenCalledWith({
+        where: { userId: 1, groupId: 2 },
+      });
+    });
+
+    it('returns false when membership is missing', async () => {
+      (prisma.groupMembership.findFirst as any).mockResolvedValue(null);
+      const result = await isUserMemberOfGroup(1, 2);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('addUserToGroup', () => {
+    it('throws when user already a member', async () => {
+      (prisma.groupMembership.findFirst as any).mockResolvedValue({ id: 1 });
+      await expect(addUserToGroup(1, 2)).rejects.toThrow(
+        'User is already a member of this group.'
+      );
+    });
+
+    it('creates membership when user not member', async () => {
+      (prisma.groupMembership.findFirst as any).mockResolvedValue(null);
+      (prisma.groupMembership.create as any).mockResolvedValue({
+        id: 3,
+        userId: 1,
+        groupId: 2,
+      });
+      const result = await addUserToGroup(1, 2);
+      expect(prisma.groupMembership.create).toHaveBeenCalledWith({
+        data: { userId: 1, groupId: 2 },
+      });
+      expect(result).toEqual({ id: 3, userId: 1, groupId: 2 });
+    });
+  });
+
+  describe('regenerateInviteTokenForGroup', () => {
+    it('returns null when group not found', async () => {
+      (prisma.group.findUnique as any).mockResolvedValue(null);
+      const result = await regenerateInviteTokenForGroup(5, 1);
+      expect(result).toBeNull();
+    });
+
+    it('throws when current user is not creator', async () => {
+      (prisma.group.findUnique as any).mockResolvedValue({ id: 5, createdById: 2 });
+      await expect(regenerateInviteTokenForGroup(5, 1)).rejects.toThrow(
+        'Unauthorized to regenerate token for this group'
+      );
+    });
+
+    it('updates invite token when authorized', async () => {
+      (prisma.group.findUnique as any).mockResolvedValue({ id: 5, createdById: 1 });
+      (prisma.group.update as any).mockResolvedValue({ id: 5, inviteToken: 'test-uuid' });
+      const result = await regenerateInviteTokenForGroup(5, 1);
+      expect(uuidv4).toHaveBeenCalled();
+      expect(prisma.group.update).toHaveBeenCalledWith({
+        where: { id: 5 },
+        data: { inviteToken: 'test-uuid' },
+      });
+      expect(result).toEqual({ id: 5, inviteToken: 'test-uuid' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- test auth helpers for cookie/header cases
- add tests for groupService utilities
- cover eventService mapping and result updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448e660f9c832485ac639772380637