### PR TITLE
Extend unit tests for user and leadership services

### DIFF
--- a/src/app/api/lib/userService.test.ts
+++ b/src/app/api/lib/userService.test.ts
@@ -1,0 +1,116 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+vi.mock('./prisma', () => ({
+  prisma: {
+    user: { findUnique: vi.fn(), create: vi.fn() },
+  },
+}));
+vi.mock('./hash', () => ({
+  hashPassword: vi.fn(),
+  verifyPassword: vi.fn(),
+}));
+vi.mock('./jwt', () => ({
+  signJwt: vi.fn(() => 'signed-token'),
+}));
+
+const { prisma } = await import('./prisma');
+const { hashPassword, verifyPassword } = await import('./hash');
+const { signJwt } = await import('./jwt');
+const { createUser, authenticateUser } = await import('./userService');
+
+describe('userService', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('createUser', () => {
+    it('throws when email already registered', async () => {
+      (prisma.user.findUnique as any).mockResolvedValue({ id: 1 });
+      await expect(createUser('a@example.com', 'Alice', 'pass')).rejects.toThrow(
+        'Email already registered.'
+      );
+    });
+
+    it('creates user with hashed password', async () => {
+      (prisma.user.findUnique as any).mockResolvedValue(null);
+      (hashPassword as any).mockResolvedValue('hashed');
+      const created = {
+        id: 1,
+        email: 'a@example.com',
+        name: 'Alice',
+        isActive: true,
+        createdAt: new Date('2020-01-01T00:00:00Z'),
+        updatedAt: new Date('2020-01-02T00:00:00Z'),
+      };
+      (prisma.user.create as any).mockResolvedValue(created);
+
+      const result = await createUser('a@example.com', 'Alice', 'secret');
+      expect(hashPassword).toHaveBeenCalledWith('secret');
+      expect(prisma.user.create).toHaveBeenCalled();
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe('authenticateUser', () => {
+    it('returns null when user not found', async () => {
+      (prisma.user.findUnique as any).mockResolvedValue(null);
+      const result = await authenticateUser('a@example.com', 'pass');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when user inactive', async () => {
+      (prisma.user.findUnique as any).mockResolvedValue({
+        id: 1,
+        email: 'a@example.com',
+        name: 'Alice',
+        hashedPassword: 'hash',
+        isActive: false,
+      });
+      const result = await authenticateUser('a@example.com', 'pass');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when password invalid', async () => {
+      (prisma.user.findUnique as any).mockResolvedValue({
+        id: 1,
+        email: 'a@example.com',
+        name: 'Alice',
+        hashedPassword: 'hash',
+        isActive: true,
+      });
+      (verifyPassword as any).mockResolvedValue(false);
+      const result = await authenticateUser('a@example.com', 'pass');
+      expect(verifyPassword).toHaveBeenCalledWith('pass', 'hash');
+      expect(result).toBeNull();
+    });
+
+    it('returns token and user when valid', async () => {
+      const user = {
+        id: 1,
+        email: 'a@example.com',
+        name: 'Alice',
+        hashedPassword: 'hash',
+        isActive: true,
+        createdAt: new Date('2020-01-01T00:00:00Z'),
+        updatedAt: new Date('2020-01-02T00:00:00Z'),
+      };
+      (prisma.user.findUnique as any).mockResolvedValue(user);
+      (verifyPassword as any).mockResolvedValue(true);
+
+      const result = await authenticateUser('a@example.com', 'pass');
+      expect(signJwt).toHaveBeenCalledWith({ sub: user.id });
+      expect(result).toEqual({
+        token: 'signed-token',
+        user: {
+          id: 1,
+          email: 'a@example.com',
+          name: 'Alice',
+          isActive: true,
+          createdAt: user.createdAt,
+          updatedAt: user.updatedAt,
+        },
+      });
+    });
+  });
+});
+

--- a/src/app/api/services/leadershipService.test.ts
+++ b/src/app/api/services/leadershipService.test.ts
@@ -1,0 +1,77 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+vi.mock('@/app/api/lib/prisma', () => ({
+  prisma: {
+    tip: { findMany: vi.fn() },
+    leadershipStreak: {
+      updateMany: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+const { prisma } = await import('@/app/api/lib/prisma');
+const { calculateHighscoresForGroup, updateLeadershipStreaks } = await import('./leadershipService');
+
+describe('leadershipService', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('calculateHighscoresForGroup', () => {
+    it('returns empty array when no tips', async () => {
+      (prisma.tip.findMany as any).mockResolvedValue([]);
+      const result = await calculateHighscoresForGroup(1);
+      expect(result).toEqual([]);
+    });
+
+    it('aggregates and sorts tips by points', async () => {
+      (prisma.tip.findMany as any).mockResolvedValue([
+        { userId: 1, points: 5, user: { name: 'Alice' } },
+        { userId: 2, points: 10, user: { name: 'Bob' } },
+        { userId: 1, points: 3, user: { name: 'Alice' } },
+      ]);
+      const result = await calculateHighscoresForGroup(2);
+      expect(result).toEqual([
+        { userId: 2, totalPoints: 10, name: 'Bob' },
+        { userId: 1, totalPoints: 8, name: 'Alice' },
+      ]);
+      expect(prisma.tip.findMany).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateLeadershipStreaks', () => {
+    it('ends active streaks when no highscores', async () => {
+      (prisma.tip.findMany as any).mockResolvedValue([]);
+      (prisma.leadershipStreak.updateMany as any).mockResolvedValue({ count: 1 });
+
+      await updateLeadershipStreaks(5);
+      expect(prisma.leadershipStreak.updateMany).toHaveBeenCalledWith({
+        where: { groupId: 5, endedOn: null },
+        data: { endedOn: expect.any(Date) },
+      });
+      expect(prisma.leadershipStreak.create).not.toHaveBeenCalled();
+    });
+
+    it('starts new streak for new leader', async () => {
+      (prisma.tip.findMany as any).mockResolvedValue([
+        { userId: 1, points: 10, user: { name: 'Alice' } },
+      ]);
+      (prisma.leadershipStreak.findMany as any).mockResolvedValue([]);
+
+      await updateLeadershipStreaks(3);
+      expect(prisma.leadershipStreak.create).toHaveBeenCalledWith({
+        data: {
+          groupId: 3,
+          userId: 1,
+          becameLeaderOn: expect.any(Date),
+          endedOn: null,
+        },
+      });
+      expect(prisma.leadershipStreak.updateMany).not.toHaveBeenCalled();
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for `userService` covering registration and authentication logic
- add tests for `leadershipService` covering highscore calculation and streak updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844921884dc8324a6b92cc99cc161bf