### PR TITLE
Allow wildcard updates

### DIFF
--- a/src/app/components/dashboard/SelectedGroupView.tsx
+++ b/src/app/components/dashboard/SelectedGroupView.tsx
@@ -139,12 +139,19 @@ export function SelectedGroupView({
         allTipsPerEvent={allTipsPerEvent}
         resultInputs={interactions.resultInputs}
         isSettingResult={interactions.isSettingResult}
+        isSubmittingTip={interactions.isSubmittingTip}
+        selectedTips={interactions.selectedTips}
         onResultInputChangeAction={interactions.handleResultInputChange}
         onSetResultAction={interactions.handleSetResult}
         // NEU:
         wildcardResultInputs={wildcardResultInputs}
         onWildcardResultInputChangeAction={handleWildcardResultInputChange}
         onSetWildcardResultAction={handleSetWildcardResult}
+        wildcardInputs={interactions.wildcardInputs}
+        onWildcardInputChangeAction={interactions.handleWildcardInputChange}
+        onSelectTipAction={interactions.handleOptionSelect}
+        onSubmitTipAction={interactions.handleSubmitTip}
+        onClearSelectedTipAction={interactions.handleClearSelectedTip}
       />
 
       <ClosedEventsCard

--- a/src/app/components/dashboard/SingleOpenEventItem.tsx
+++ b/src/app/components/dashboard/SingleOpenEventItem.tsx
@@ -99,13 +99,15 @@ export function SingleOpenEventItem({
   const currentUserTipForThisEvent = userSubmittedTips[event.id];
   const userHasSubmittedTip = !!currentUserTipForThisEvent;
   const selectedOptionForTipping = selectedTips[event.id];
-  const wildcardGuessValue = wildcardInputs[event.id] || '';
   const isSubmittingCurrentEventTip = isSubmittingTip[event.id];
   const isSettingCurrentEventResult = isSettingResult[event.id];
   const currentResultInputForEvent = resultInputs[event.id] || '';
   const currentUserTipDetails = allTipsForThisEvent.find(
     (tip) => tip.userId === user?.id
   );
+  const wildcardGuessValue =
+    wildcardInputs[event.id] ??
+    (userHasSubmittedTip ? currentUserTipDetails?.wildcardGuess || '' : '');
   const optionVoteCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     allTipsForThisEvent?.forEach((tip) => {
@@ -324,6 +326,39 @@ export function SingleOpenEventItem({
               )}
             </div>
           </div>
+        </div>
+      )}
+
+      {event.hasWildcard && isTippingAllowed && userHasSubmittedTip && (
+        <div className='mt-4 p-3 border rounded-md bg-muted/10 space-y-2'>
+          <div className='flex items-center gap-2'>
+            <Info className='h-4 w-4 text-blue-500' />
+            <p className='text-sm font-medium text-foreground'>Wildcard anpassen</p>
+          </div>
+          <p className='text-xs text-muted-foreground break-words'>
+            {event.wildcardPrompt || 'Gib deinen Wert für die Wildcard ein.'}
+          </p>
+          <input
+            type='text'
+            placeholder='Dein Wildcard-Tipp…'
+            value={wildcardGuessValue}
+            onChange={(e) => onWildcardInputChangeAction(event.id, e.target.value)}
+            className='mt-1 w-full border rounded-md p-2 text-sm'
+            disabled={isSubmittingCurrentEventTip}
+          />
+          <Button
+            onClick={() => {
+              onSelectTipAction(event.id, currentUserTipForThisEvent);
+              onSubmitTipAction(event.id, wildcardGuessValue);
+            }}
+            disabled={isSubmittingCurrentEventTip}
+            className='w-full sm:w-auto'
+          >
+            {isSubmittingCurrentEventTip && (
+              <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+            )}
+            Wildcard speichern
+          </Button>
         </div>
       )}
 

--- a/src/app/components/dashboard/SubmittedOpenEventsCard.tsx
+++ b/src/app/components/dashboard/SubmittedOpenEventsCard.tsx
@@ -30,6 +30,8 @@ interface SubmittedOpenEventsCardProps {
   allTipsPerEvent: AllTipsPerEvent;
   resultInputs: Record<number, string>;
   isSettingResult: Record<number, boolean>;
+  isSubmittingTip: Record<number, boolean>;
+  selectedTips: Record<number, string>;
   onResultInputChangeAction: (eventId: number, value: string) => void;
   onSetResultAction: (eventId: number, winningOption: string) => Promise<void>;
   wildcardResultInputs: Record<number, string>;
@@ -38,6 +40,11 @@ interface SubmittedOpenEventsCardProps {
     eventId: number,
     wildcardResult: string
   ) => Promise<void>;
+  wildcardInputs: Record<number, string>;
+  onWildcardInputChangeAction: (eventId: number, value: string) => void;
+  onSelectTipAction: (eventId: number, option: string) => void;
+  onSubmitTipAction: (eventId: number, wildcardGuess?: string) => Promise<void>;
+  onClearSelectedTipAction: (eventId: number) => void;
 }
 
 export default function SubmittedOpenEventsCard({
@@ -49,11 +56,18 @@ export default function SubmittedOpenEventsCard({
   allTipsPerEvent,
   resultInputs,
   isSettingResult,
+  isSubmittingTip,
+  selectedTips,
   onResultInputChangeAction,
   onSetResultAction,
   wildcardResultInputs,
   onWildcardResultInputChangeAction,
   onSetWildcardResultAction,
+  wildcardInputs,
+  onWildcardInputChangeAction,
+  onSelectTipAction,
+  onSubmitTipAction,
+  onClearSelectedTipAction,
 }: SubmittedOpenEventsCardProps) {
   const [isOpen, setIsOpen] = useState(true);
 
@@ -104,19 +118,19 @@ export default function SubmittedOpenEventsCard({
                   user={user}
                   groupCreatedBy={groupCreatedBy}
                   onInitiateDeleteEventAction={onInitiateDeleteEventAction}
-                  selectedTips={{}}
+                  selectedTips={selectedTips}
                   userSubmittedTips={userSubmittedTips}
                   allTipsForThisEvent={allTipsPerEvent[event.id] || []}
                   resultInputs={resultInputs}
-                  isSubmittingTip={{}}
+                  isSubmittingTip={isSubmittingTip}
                   isSettingResult={isSettingResult}
-                  onSelectTipAction={() => {}}
-                  onSubmitTipAction={async () => {}}
+                  onSelectTipAction={onSelectTipAction}
+                  onSubmitTipAction={onSubmitTipAction}
                   onResultInputChangeAction={onResultInputChangeAction}
                   onSetResultAction={onSetResultAction}
-                  onClearSelectedTipAction={() => {}}
-                  wildcardInputs={{}}
-                  onWildcardInputChangeAction={() => {}}
+                  onClearSelectedTipAction={onClearSelectedTipAction}
+                  wildcardInputs={wildcardInputs}
+                  onWildcardInputChangeAction={onWildcardInputChangeAction}
                   wildcardResultInputs={wildcardResultInputs}
                   onWildcardResultInputChangeAction={
                     onWildcardResultInputChangeAction


### PR DESCRIPTION
## Summary
- let users modify wildcard guess before deadline even after submitting a tip
- pass interaction props to SubmittedOpenEventsCard
- show wildcard input in submitted events and allow saving

## Testing
- `npm test`
- `npm run build:ci` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68452ca3165c832493e340f9128bd65b