### PR TITLE
Add register page unit test

### DIFF
--- a/src/app/api/services/leadershipService.test.ts
+++ b/src/app/api/services/leadershipService.test.ts
@@ -49,8 +49,8 @@ describe('leadershipService', () => {
 
       await updateLeadershipStreaks(5);
       expect(prisma.leadershipStreak.updateMany).toHaveBeenCalledWith({
-        where: { groupId: 5, endedOn: null },
-        data: { endedOn: expect.any(Date) },
+        where: { groupId: 5, ended_on: null },
+        data: { ended_on: expect.any(Date) },
       });
       expect(prisma.leadershipStreak.create).not.toHaveBeenCalled();
     });
@@ -67,7 +67,7 @@ describe('leadershipService', () => {
           groupId: 3,
           userId: 1,
           becameLeaderOn: expect.any(Date),
-          endedOn: null,
+          ended_on: null,
         },
       });
       expect(prisma.leadershipStreak.updateMany).not.toHaveBeenCalled();

--- a/src/app/register/page.test.tsx
+++ b/src/app/register/page.test.tsx
@@ -1,0 +1,82 @@
+import {
+  render,
+  screen,
+  waitFor,
+  cleanup,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import RegisterPage from './page';
+
+/* ------------------ Mocks ------------------ */
+var mockRegisterUser: any;
+const mockPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('@/app/lib/api', () => {
+  mockRegisterUser = vi.fn(async () => ({}));
+  return {
+    registerUser: mockRegisterUser,
+    ApiError: class ApiError extends Error {},
+  };
+});
+
+/* ------------------ Tests ------------------ */
+describe('RegisterPage', () => {
+  beforeAll(() => {
+    // Ensure React is available globally for classic runtime JSX
+    // @ts-ignore
+    globalThis.React = React;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  it('renders registration form fields', async () => {
+    render(<RegisterPage />);
+    expect(await screen.findByPlaceholderText('Dein Name')).toBeTruthy();
+    expect(await screen.findByPlaceholderText('deine@email.de')).toBeTruthy();
+    expect(await screen.findAllByPlaceholderText('********')).toHaveLength(2);
+    expect(
+      screen.getByRole('button', { name: /Konto erstellen/i })
+    ).toBeTruthy();
+  });
+
+  it('submits data and redirects to login', async () => {
+    const user = userEvent.setup();
+    render(<RegisterPage />);
+
+    await user.type(screen.getByPlaceholderText('Dein Name'), 'Max');
+    await user.type(
+      screen.getByPlaceholderText('deine@email.de'),
+      'max@example.com'
+    );
+    const passwords = screen.getAllByPlaceholderText('********');
+    await user.type(passwords[0], 'secretpass');
+    await user.type(passwords[1], 'secretpass');
+
+    await user.click(screen.getByRole('button', { name: /Konto erstellen/i }));
+
+    await waitFor(() =>
+      expect(mockRegisterUser).toHaveBeenCalledWith({
+        email: 'max@example.com',
+        name: 'Max',
+        password: 'secretpass',
+      })
+    );
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add RegisterPage unit tests covering form and submit behaviour
- update leadership service tests for new snake_case fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68455fea1570832482b90018f3dd9971