### PR TITLE
Add tests for previously untested modules

### DIFF
--- a/src/app/api/generate-ai-bet/route.test.ts
+++ b/src/app/api/generate-ai-bet/route.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('groq-sdk', () => ({ Groq: vi.fn(() => ({})) }));
+import { extractAIFieldsFromServer } from './route';
+
+describe('extractAIFieldsFromServer', () => {
+  it('parses ai response sections', () => {
+    const text = `Titel: Test
+Frage: Wer gewinnt?
+Beschreibung: Info
+Optionen:
+1. A
+2. B
+Wildcard: Ergebnis?`;
+    const result = extractAIFieldsFromServer(text);
+    expect(result.title).toBe('Test');
+    expect(result.question).toBe('Wer gewinnt?');
+    expect(result.description).toBe('Info');
+    expect(result.options).toEqual(['A', 'B']);
+    expect(result.wildcard_prompt).toBe('Ergebnis?');
+  });
+});

--- a/src/app/api/generate-ai-bet/route.ts
+++ b/src/app/api/generate-ai-bet/route.ts
@@ -139,7 +139,7 @@ interface ParsedAIBet {
   wildcard_prompt?: string;
 }
 
-function extractAIFieldsFromServer(text: string): Partial<ParsedAIBet> {
+export function extractAIFieldsFromServer(text: string): Partial<ParsedAIBet> {
   const sections = text
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')

--- a/src/app/api/groups/[groupId]/route.test.ts
+++ b/src/app/api/groups/[groupId]/route.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/app/api/lib/auth', () => ({ getCurrentUserFromRequest: vi.fn() }));
+vi.mock('@/app/api/services/groupService', () => ({ isUserMemberOfGroup: vi.fn() }));
+vi.mock('@/app/api/lib/prisma', () => ({ prisma: { group: { findUnique: vi.fn() } } }));
+
+const { getCurrentUserFromRequest } = await import('@/app/api/lib/auth');
+const { isUserMemberOfGroup } = await import('@/app/api/services/groupService');
+const { prisma } = await import('@/app/api/lib/prisma');
+const { GET } = await import('./route');
+
+describe('GET /api/groups/[groupId]', () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it('returns group details when authorized', async () => {
+    (getCurrentUserFromRequest as any).mockResolvedValue({ id: 1 });
+    (isUserMemberOfGroup as any).mockResolvedValue(true);
+    (prisma.group.findUnique as any).mockResolvedValue({ id: 2, name: 'G' });
+
+    const req = new NextRequest('http://localhost/api/groups/2');
+    const res = await GET(req, { params: { groupId: '2' } } as any);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.name).toBe('G');
+  });
+});

--- a/src/app/api/services/espn_scraper.test.ts
+++ b/src/app/api/services/espn_scraper.test.ts
@@ -1,0 +1,41 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import axios from 'axios';
+
+vi.mock('axios');
+
+const html = `
+  <h2>Key Dates</h2>
+  <ul>
+    <li>Sept. 12: Las Vegas (ESPN) -- Title Fight</li>
+    <li>Oct. 5: New York (DAZN) -- Another Fight</li>
+  </ul>
+`;
+
+const { fetchAndParseBoxingSchedule } = await import('./espn_scraper');
+
+const mockedAxios = axios as unknown as { get: any };
+
+describe('fetchAndParseBoxingSchedule', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('parses boxing events from ESPN schedule', async () => {
+    mockedAxios.get.mockResolvedValue({ data: html });
+    const events = await fetchAndParseBoxingSchedule();
+    expect(mockedAxios.get).toHaveBeenCalled();
+    expect(events.length).toBe(2);
+    expect(events[0]).toMatchObject({
+      date: 'Sept. 12',
+      location: 'Las Vegas',
+      broadcaster: 'ESPN',
+      details: 'Title Fight',
+    });
+    expect(events[0].parsedDate).toMatch(/^\d{4}-/);
+  });
+
+  it('returns empty array on http error', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('fail'));
+    await expect(fetchAndParseBoxingSchedule()).rejects.toThrow();
+  });
+});

--- a/src/app/api/services/football_schedule_fetch.test.ts
+++ b/src/app/api/services/football_schedule_fetch.test.ts
@@ -1,0 +1,46 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import axios from 'axios';
+
+vi.mock('axios');
+
+const matches = [
+  {
+    matchID: 1,
+    matchDateTimeUTC: '2023-01-10T12:00:00Z',
+    matchIsFinished: true,
+    matchResults: [
+      { resultName: 'Endergebnis', pointsTeam1: 2, pointsTeam2: 1 },
+    ],
+    team1: { teamName: 'A' },
+    team2: { teamName: 'B' },
+  },
+  {
+    matchID: 2,
+    matchDateTimeUTC: '2023-02-10T12:00:00Z',
+    matchIsFinished: false,
+    team1: { teamName: 'C' },
+    team2: { teamName: 'D' },
+  },
+];
+
+const { fetchAndParseOpenLigaCompetition } = await import('./football_schedule');
+const mockedAxios = axios as unknown as { get: any };
+
+describe('fetchAndParseOpenLigaCompetition', () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it('maps and filters matches', async () => {
+    mockedAxios.get.mockResolvedValue({ data: matches });
+    const from = new Date('2023-01-01T00:00:00Z');
+    const to = new Date('2023-01-31T00:00:00Z');
+    const events = await fetchAndParseOpenLigaCompetition('bl1', '2023', from, to);
+    expect(events.length).toBe(1);
+    expect(events[0]).toMatchObject({
+      matchID: 1,
+      homeTeam: 'A',
+      awayTeam: 'B',
+      result: '2 : 1',
+      status: 'FINISHED',
+    });
+  });
+});

--- a/src/app/api/services/notificationService.test.ts
+++ b/src/app/api/services/notificationService.test.ts
@@ -1,0 +1,34 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+vi.mock('web-push', () => ({ default: { setVapidDetails: vi.fn(), sendNotification: vi.fn() } }));
+vi.mock('@/app/api/lib/prisma', () => ({
+  prisma: {
+    groupMembership: { findMany: vi.fn() },
+    pushSubscription: { delete: vi.fn() },
+  },
+}));
+
+const { prisma } = await import('@/app/api/lib/prisma');
+const webPush = (await import('web-push')).default as any;
+const { sendNewEventNotificationsToGroupMembers } = await import('./notificationService');
+
+describe('sendNewEventNotificationsToGroupMembers', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    delete process.env.VAPID_PUBLIC_KEY;
+  });
+
+  it('does nothing when vapid key missing', async () => {
+    await sendNewEventNotificationsToGroupMembers({ id: 1, groupId: 2, groupName: 'G', title: 'E' } as any, 1);
+    expect(prisma.groupMembership.findMany).not.toHaveBeenCalled();
+  });
+
+  it('sends notifications to members', async () => {
+    process.env.VAPID_PUBLIC_KEY = 'x';
+    prisma.groupMembership.findMany.mockResolvedValue([
+      { user: { id: 2, pushSubscriptions: [{ id: 1, endpoint: 'e', p256dh: 'd', auth: 'a' }] } },
+    ]);
+    await sendNewEventNotificationsToGroupMembers({ id: 1, groupId: 2, groupName: 'G', title: 'E' } as any, 1);
+    expect(webPush.sendNotification).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/services/ufc_calendar.test.ts
+++ b/src/app/api/services/ufc_calendar.test.ts
@@ -1,0 +1,41 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import axios from 'axios';
+
+vi.mock('axios');
+
+const ics = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:1
+SUMMARY:UFC 1
+LOCATION:Las Vegas
+DESCRIPTION:desc
+DTSTART:20300101T100000Z
+DTEND:20300101T120000Z
+END:VEVENT
+END:VCALENDAR`;
+
+const { fetchAndParseUfcSchedule } = await import('./ufc_calendar');
+
+const mockedAxios = axios as unknown as { get: any };
+
+describe('fetchAndParseUfcSchedule', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('parses upcoming UFC events', async () => {
+    mockedAxios.get.mockResolvedValue({ data: ics });
+    const events = await fetchAndParseUfcSchedule();
+    expect(mockedAxios.get).toHaveBeenCalled();
+    expect(events[0]).toMatchObject({
+      summary: 'UFC 1',
+      location: 'Las Vegas',
+    });
+    expect(events[0].dtstart).toBe('2030-01-01T10:00:00.000Z');
+  });
+
+  it('throws on error', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('fail'));
+    await expect(fetchAndParseUfcSchedule()).rejects.toThrow();
+  });
+});

--- a/src/app/hooks/useDashboardData.test.tsx
+++ b/src/app/hooks/useDashboardData.test.tsx
@@ -1,0 +1,19 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/app/context/AuthContext', () => ({
+  useAuth: () => ({ token: null, user: null, isLoading: false })
+}));
+vi.mock('@/app/lib/api', () => ({
+  getMyGroups: vi.fn(),
+}));
+
+const { useDashboardData } = await import('./useDashboardData');
+
+describe('useDashboardData', () => {
+  it('initializes with empty groups when not authenticated', async () => {
+    const { result } = renderHook(() => useDashboardData());
+    expect(result.current.myGroups).toEqual([]);
+    expect(result.current.selectedGroupId).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ESPN scraper
- add tests for UFC calendar parsing
- add OpenLiga fetch tests
- test push notifications
- test group GET route
- export AI helper and test parsing
- test dashboard hook defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845d3f7996c8324aeb321e1ee070684