### PR TITLE
Add component tests

### DIFF
--- a/src/app/components/dashboard/EventList.test.tsx
+++ b/src/app/components/dashboard/EventList.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { EventList } from './EventList';
+
+const sampleEvent = {
+  id: '1',
+  title: 'Sample Event',
+  subtitle: 'Main event',
+  sport: 'ufc',
+  date: new Date(),
+  original: { summary: null, location: null, description: null, uid: null, dtstart: null, dtend: null },
+};
+
+describe('EventList', () => {
+  beforeAll(() => {
+    // Ensure React is available globally for classic runtime JSX
+    // @ts-ignore
+    globalThis.React = React;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  it('shows fallback when empty', () => {
+    render(<EventList events={[]} onProposeEvent={vi.fn()} disabled={false} />);
+    expect(screen.getByText('Keine bevorstehenden Events gefunden.')).toBeTruthy();
+  });
+
+  it('renders events and handles click', async () => {
+    const onPropose = vi.fn();
+    render(<EventList events={[sampleEvent]} onProposeEvent={onPropose} disabled={false} />);
+    expect(screen.getByText('Sample Event')).toBeTruthy();
+    const btn = screen.getByRole('button', { name: /wette hinzufügen/i });
+    await userEvent.setup().click(btn);
+    expect(onPropose).toHaveBeenCalledWith('1');
+  });
+
+  it('disables buttons when disabled', () => {
+    const onPropose = vi.fn();
+    render(<EventList events={[sampleEvent]} onProposeEvent={onPropose} disabled={true} />);
+    const btn = screen.getByRole('button', { name: /wette hinzufügen/i });
+    expect(btn.getAttribute('disabled')).not.toBeNull();
+  });
+});

--- a/src/app/components/dashboard/EventListPublic.test.tsx
+++ b/src/app/components/dashboard/EventListPublic.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { EventListPublic } from './EventListPublic';
+
+const publicEvent = {
+  id: 'pub1',
+  title: 'Public Fight',
+  subtitle: 'Main',
+  sport: 'boxing',
+  date: new Date(),
+  original: { date: null, location: null, broadcaster: null, details: null },
+};
+
+describe('EventListPublic', () => {
+  beforeAll(() => {
+    // Ensure React is available globally for classic runtime JSX
+    // @ts-ignore
+    globalThis.React = React;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  it('shows fallback when empty', () => {
+    render(<EventListPublic events={[]} onProposeEvent={vi.fn()} />);
+    expect(
+      screen.getByText('Momentan keine öffentlichen Events verfügbar.')
+    ).toBeTruthy();
+  });
+
+  it('renders events and handles click', async () => {
+    const onPropose = vi.fn();
+    render(<EventListPublic events={[publicEvent]} onProposeEvent={onPropose} />);
+    expect(screen.getByText('Public Fight')).toBeTruthy();
+    const btn = screen.getByRole('button', { name: /wette hinzufügen/i });
+    await userEvent.setup().click(btn);
+    expect(onPropose).toHaveBeenCalledWith(publicEvent.original);
+  });
+});

--- a/src/app/components/dashboard/LoaderBlock.test.tsx
+++ b/src/app/components/dashboard/LoaderBlock.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { LoaderBlock } from './LoaderBlock';
+
+describe('LoaderBlock', () => {
+  beforeAll(() => {
+    // Ensure React is available globally for classic runtime JSX
+    // @ts-ignore
+    globalThis.React = React;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows spinner and text', () => {
+    render(<LoaderBlock text="Loading" />);
+    expect(screen.getByRole('status')).toBeTruthy();
+    expect(screen.getByText('Loading')).toBeTruthy();
+  });
+});

--- a/src/app/components/dashboard/NoGroupsCard.test.tsx
+++ b/src/app/components/dashboard/NoGroupsCard.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { NoGroupsCard } from './NoGroupsCard';
+
+describe('NoGroupsCard', () => {
+  beforeAll(() => {
+    // Ensure React is available globally for classic runtime JSX
+    // @ts-ignore
+    globalThis.React = React;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders welcome text and create link', () => {
+    render(<NoGroupsCard />);
+    expect(screen.getByText('Willkommen bei fbet!')).toBeTruthy();
+    const link = screen.getByRole('link', { name: /gruppe erstellen/i });
+    expect(link.getAttribute('href')).toBe('/groups/create');
+  });
+});

--- a/src/app/components/event/EventCard.test.tsx
+++ b/src/app/components/event/EventCard.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { EventCard } from './EventCard';
+
+describe('EventCard', () => {
+  beforeAll(() => {
+    // Ensure React is available globally for classic runtime JSX
+    // @ts-ignore
+    globalThis.React = React;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  const baseProps = {
+    title: 'Fight Night',
+    subtitle: 'A vs B',
+  };
+
+  it('renders title and subtitle', () => {
+    render(<EventCard {...baseProps} />);
+    expect(screen.getByText('Fight Night')).toBeTruthy();
+    expect(screen.getByText('A vs B')).toBeTruthy();
+  });
+
+  it('calls onClick when add bet button clicked', async () => {
+    const handleClick = vi.fn();
+    render(<EventCard {...baseProps} onClick={handleClick} />);
+    const btn = screen.getByRole('button', { name: /wette hinzufügen/i });
+    await userEvent.setup().click(btn);
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('calls onAiCreateClick when AI button clicked', async () => {
+    const handleAi = vi.fn();
+    render(<EventCard {...baseProps} onAiCreateClick={handleAi} />);
+    const aiBtn = screen.getByTitle('AI-Wettvorschlag für dieses Event generieren');
+    await userEvent.setup().click(aiBtn);
+    expect(handleAi).toHaveBeenCalledWith({ title: 'Fight Night', subtitle: 'A vs B', badge: undefined });
+  });
+
+  it('disables buttons when disabled', () => {
+    render(
+      <EventCard {...baseProps} disabled onClick={vi.fn()} onAiCreateClick={vi.fn()} />
+    );
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach((btn) =>
+      expect(btn.getAttribute('disabled')).not.toBeNull()
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for EventCard component
- cover EventList and EventListPublic
- test LoaderBlock and NoGroupsCard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845e3b786cc832480835b412d720aec