### PR TITLE
Add extra unit tests

### DIFF
--- a/tests/unit/app/api/services/football_schedule_austria.test.ts
+++ b/tests/unit/app/api/services/football_schedule_austria.test.ts
@@ -1,0 +1,61 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import axios from 'axios';
+
+vi.mock('axios');
+
+const matches = [
+  {
+    matchID: 1,
+    matchDateTimeUTC: '2023-01-10T12:00:00Z',
+    matchIsFinished: true,
+    matchResults: [
+      { resultName: 'Endergebnis', pointsTeam1: 3, pointsTeam2: 2 },
+    ],
+    team1: { teamName: 'A' },
+    team2: { teamName: 'B' },
+  },
+  {
+    matchID: 2,
+    matchDateTimeUTC: '2023-01-15T12:00:00Z',
+    matchIsFinished: false,
+    team1: { teamName: 'N/A' },
+    team2: { teamName: 'N/A' },
+  },
+  {
+    matchID: 3,
+    matchDateTimeUTC: '2023-02-10T12:00:00Z',
+    matchIsFinished: false,
+    team1: { teamName: 'C' },
+    team2: { teamName: 'D' },
+  },
+];
+
+const { fetchAndParseAustriaMatchesOpenLiga } = await import('@/app/api/services/football_schedule');
+const mockedAxios = axios as unknown as { get: any };
+
+describe('fetchAndParseAustriaMatchesOpenLiga', () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it('maps and filters matches', async () => {
+    mockedAxios.get.mockResolvedValue({ data: matches });
+    const from = new Date('2023-01-01T00:00:00Z');
+    const to = new Date('2023-01-31T00:00:00Z');
+    const events = await fetchAndParseAustriaMatchesOpenLiga('148', from, to);
+    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('148'), expect.any(Object));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      matchID: 1,
+      homeTeam: 'A',
+      awayTeam: 'B',
+      result: '3 : 2',
+    });
+  });
+
+  it('returns empty array on error', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('fail'));
+    const from = new Date('2023-01-01T00:00:00Z');
+    const to = new Date('2023-01-31T00:00:00Z');
+    const result = await fetchAndParseAustriaMatchesOpenLiga('148', from, to);
+    expect(result).toEqual([]);
+  });
+});

--- a/tests/unit/app/lib/utils.test.tsx
+++ b/tests/unit/app/lib/utils.test.tsx
@@ -22,4 +22,19 @@ describe('utils', () => {
   it('merges class names', () => {
     expect(cn('a', false && 'b', 'c')).toBe('a c');
   });
+
+  it('handles defaults and case-insensitive values', () => {
+    const { container: s1 } = render(<>{getSportIcon(undefined)}</>);
+    expect(s1.querySelector('svg')).toBeTruthy();
+    const { container: s2 } = render(<>{getSportIcon('UFC')}</>);
+    expect(s2.querySelector('svg')).toBeTruthy();
+    const { container: c1 } = render(<>{getCategoryIcon(undefined)}</>);
+    expect(c1.querySelector('svg')).toBeTruthy();
+    const { container: c2 } = render(<>{getCategoryIcon('BoXeN')}</>);
+    expect(c2.querySelector('svg')).toBeTruthy();
+  });
+
+  it('merges complex class name inputs', () => {
+    expect(cn('a', ['b', false, 'c'], undefined, 'd')).toBe('a b c d');
+  });
 });


### PR DESCRIPTION
## Summary
- add additional edge case tests for util helpers
- add new tests for Austria match parsing logic

## Testing
- `npm run test:unit`
- `npm run test:component`


------
https://chatgpt.com/codex/tasks/task_e_6846ee2c0af0832488eadb6fbce294b6