### PR TITLE
Improve component test coverage

### DIFF
--- a/tests/component/components/dashboard/EventList.test.tsx
+++ b/tests/component/components/dashboard/EventList.test.tsx
@@ -45,4 +45,33 @@ describe('EventList', () => {
     const btn = screen.getByRole('button', { name: /wette hinzufügen/i });
     expect(btn.getAttribute('disabled')).not.toBeNull();
   });
+
+  it('calls onCardAiCreate with translated badge', async () => {
+    const onAi = vi.fn();
+    const event = { ...sampleEvent, sport: 'boxing', id: '2' } as any;
+    render(
+      <EventList
+        events={[event]}
+        onProposeEvent={vi.fn()}
+        onCardAiCreate={onAi}
+        disabled={false}
+      />
+    );
+    const aiBtn = screen.getByTitle('AI-Wettvorschlag für dieses Event generieren');
+    await userEvent.setup().click(aiBtn);
+    expect(onAi).toHaveBeenCalledWith({
+      title: 'Sample Event',
+      subtitle: 'Main event',
+      badge: 'Boxen',
+    });
+  });
+
+  it('uses fallback id when event has none', async () => {
+    const onPropose = vi.fn();
+    const event = { ...sampleEvent, id: '' } as any;
+    render(<EventList events={[event]} onProposeEvent={onPropose} disabled={false} />);
+    const btn = screen.getByRole('button', { name: /wette hinzufügen/i });
+    await userEvent.setup().click(btn);
+    expect(onPropose).toHaveBeenCalledWith('fallback-0');
+  });
 });

--- a/tests/component/components/layout/AppHeader.test.tsx
+++ b/tests/component/components/layout/AppHeader.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
 import { AppHeader } from '@/app/components/layout/AppHeader';
@@ -7,26 +8,31 @@ vi.mock('next/link', () => ({
   default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
 }));
 
+const appRefreshMock = {
+  refresh: vi.fn(),
+  updateAvailable: false,
+  online: true,
+  isRefreshing: false,
+};
 vi.mock('@/app/hooks/useAppRefresh', () => ({
-  useAppRefresh: () => ({
-    refresh: vi.fn(),
-    updateAvailable: false,
-    online: true,
-    isRefreshing: false,
-  }),
+  useAppRefresh: () => appRefreshMock,
 }));
 
+let pushMock: any = {
+  status: 'not_supported',
+  error: null,
+  requestPermissionAndSubscribe: vi.fn(),
+  unsubscribeUser: vi.fn(),
+  isSubscribed: false,
+  isLoading: false,
+  permissionDenied: false,
+};
 vi.mock('@/app/hooks/usePushNotifications', () => ({
-  PushNotificationStatus: { NOT_SUPPORTED: 'not_supported' },
-  usePushNotifications: () => ({
-    status: 'not_supported',
-    error: null,
-    requestPermissionAndSubscribe: vi.fn(),
-    unsubscribeUser: vi.fn(),
-    isSubscribed: false,
-    isLoading: false,
-    permissionDenied: false,
-  }),
+  PushNotificationStatus: {
+    NOT_SUPPORTED: 'not_supported',
+    SUPPORTED_NOT_SUBSCRIBED: 'supported_not_subscribed',
+  },
+  usePushNotifications: () => pushMock,
 }));
 
 describe('AppHeader', () => {
@@ -60,5 +66,33 @@ describe('AppHeader', () => {
     expect(screen.getByText('Hi, John!')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Logout' })).toBeTruthy();
     expect(screen.queryByText('Login')).toBeNull();
+  });
+
+  it('shows loader when refresh button clicked', async () => {
+    appRefreshMock.refresh = vi.fn();
+    appRefreshMock.updateAvailable = true;
+    const { container } = render(<AppHeader user={null} />);
+    const btn = await screen.findByLabelText('App neu laden');
+    await userEvent.setup().click(btn);
+    expect(appRefreshMock.refresh).toHaveBeenCalled();
+    expect(container.querySelector('.backdrop-blur-sm')).toBeTruthy();
+  });
+
+  it('toggles push notifications when button clicked', async () => {
+    pushMock = {
+      status: 'supported_not_subscribed',
+      error: null,
+      requestPermissionAndSubscribe: vi.fn(async () => true),
+      unsubscribeUser: vi.fn(),
+      isSubscribed: false,
+      isLoading: false,
+      permissionDenied: false,
+    };
+    render(
+      <AppHeader user={{ id: 1, email: 'a@example.com', name: 'A' }} myGroups={[]} />
+    );
+    const btn = await screen.findByLabelText('Push-Benachrichtigungen aktivieren');
+    await userEvent.setup().click(btn);
+    expect(pushMock.requestPermissionAndSubscribe).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- extend `EventList` tests to cover AI handler and fallback IDs
- enhance `AppHeader` tests with loader and push notification cases

## Testing
- `npm run test:component -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68470bb24c2883249a7475b8b362148b