### PR TITLE
Improve useDashboardData tests

### DIFF
--- a/tests/unit/app/hooks/useDashboardData.test.tsx
+++ b/tests/unit/app/hooks/useDashboardData.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('@/app/context/AuthContext', () => ({
@@ -15,5 +15,22 @@ describe('useDashboardData', () => {
     const { result } = renderHook(() => useDashboardData());
     expect(result.current.myGroups).toEqual([]);
     expect(result.current.selectedGroupId).toBe(null);
+  });
+
+  it('updates userSubmittedTips when updateUserTipState is called', async () => {
+    const { result } = renderHook(() => useDashboardData());
+    await act(async () => {
+      result.current.updateUserTipState(1, 'A');
+    });
+    expect(result.current.userSubmittedTips).toEqual({ 1: 'A' });
+  });
+
+  it('handles selecting a group and persists id to localStorage', async () => {
+    const { result } = renderHook(() => useDashboardData());
+    await act(async () => {
+      result.current.handleSelectGroup(3);
+    });
+    expect(result.current.selectedGroupId).toBe(3);
+    expect(localStorage.getItem('selectedGroupId')).toBe('3');
   });
 });


### PR DESCRIPTION
## Summary
- extend `useDashboardData` unit tests to cover state update helpers

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68471d678aa48324bfee264ffd7a1e72