### PR TITLE
Add Playwright page objects

### DIFF
--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,6 +1,8 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
+import { HomePage } from './pageObjects/HomePage';
 
 test('homepage displays hero text', async ({ page }) => {
-  await page.goto('/');
-  await expect(page.locator('text=Wetten unter Freunden – auf alles, was Spaß macht.')).toBeVisible();
+  const home = new HomePage(page);
+  await home.goto();
+  await home.expectHeroVisible();
 });

--- a/tests/e2e/pageObjects/DashboardPage.ts
+++ b/tests/e2e/pageObjects/DashboardPage.ts
@@ -1,0 +1,25 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+export class DashboardPage {
+  readonly page: Page;
+  readonly loginPrompt: Locator;
+  readonly groupDetails: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.loginPrompt = page.getByTestId('login-prompt-div');
+    this.groupDetails = page.getByTestId('group-details');
+  }
+
+  async goto() {
+    await this.page.goto('/dashboard');
+  }
+
+  async expectLoginPrompt() {
+    await expect(this.loginPrompt).toBeVisible();
+  }
+
+  async expectGroupDetailsVisible() {
+    await expect(this.groupDetails).toBeVisible();
+  }
+}

--- a/tests/e2e/pageObjects/HomePage.ts
+++ b/tests/e2e/pageObjects/HomePage.ts
@@ -1,0 +1,35 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+export class HomePage {
+  readonly page: Page;
+  readonly heroTitle: Locator;
+  readonly loginButton: Locator;
+  readonly registerButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heroTitle = page.locator(
+      'text=Wetten unter Freunden – auf alles, was Spaß macht.'
+    );
+    this.loginButton = page.getByRole('button', { name: /Einloggen/i });
+    this.registerButton = page.getByRole('button', {
+      name: /Eigene Gruppe starten/i,
+    });
+  }
+
+  async goto() {
+    await this.page.goto('/');
+  }
+
+  async expectHeroVisible() {
+    await expect(this.heroTitle).toBeVisible();
+  }
+
+  async clickLogin() {
+    await this.loginButton.click();
+  }
+
+  async clickRegister() {
+    await this.registerButton.click();
+  }
+}

--- a/tests/e2e/pageObjects/LoginPage.ts
+++ b/tests/e2e/pageObjects/LoginPage.ts
@@ -1,0 +1,29 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+export class LoginPage {
+  readonly page: Page;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emailInput = page.getByPlaceholder('name@example.com');
+    this.passwordInput = page.getByPlaceholder('••••••••');
+    this.submitButton = page.getByRole('button', { name: /Anmelden/i });
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  async login(email: string, password: string) {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.submitButton.click();
+  }
+
+  async expectEmailVisible() {
+    await expect(this.emailInput).toBeVisible();
+  }
+}

--- a/tests/e2e/pageObjects/index.ts
+++ b/tests/e2e/pageObjects/index.ts
@@ -1,0 +1,3 @@
+export * from './HomePage';
+export * from './LoginPage';
+export * from './DashboardPage';


### PR DESCRIPTION
## Summary
- add page objects for Home, Login and Dashboard pages
- use HomePage object in e2e test

## Testing
- `npx playwright install --with-deps chromium`
- `npm run test:e2e` *(fails: ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_684d4abea0f4832488579d92ec594b9d